### PR TITLE
feat: add Docker support for Jellyfin web directory detection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -88,6 +88,8 @@ get_jellyfin_web_dir() {
         "/opt/homebrew/share/jellyfin/web"
         "/opt/homebrew/opt/jellyfin/web"
         "/usr/local/opt/jellyfin/web"
+        # Docker; jellyfin/jellfin (official image) 
+        "/jellyfin/jellyfin-web" # Note: this is the path inside the container, not on the host
     )
 
     for p in "${candidates[@]}"; do


### PR DESCRIPTION
This change will make it so when the script is run inside of the docker container it can find the correct directory for jellyfin-web as it is a bit different that the native platform locations. I have tested this on my setup in docker and it worked flawlessly. Please note that I ran it at the root directory.