### PR TITLE
feat: add touch swipe functionality for carousel navigation

### DIFF
--- a/scripts/spotlight/spotlight.css
+++ b/scripts/spotlight/spotlight.css
@@ -17,6 +17,7 @@ body {
 	height: 100vh;
 	color: #fff;
 	-webkit-font-smoothing: antialiased;
+	touch-action: pan-y;
 }
 
 #backdrop {

--- a/scripts/spotlight/spotlight.html
+++ b/scripts/spotlight/spotlight.html
@@ -33,7 +33,8 @@
 	<!-- Update notification -->
 	<div id="update-toast" style="display:none" role="status" aria-live="polite">
 		<div id="update-toast-inner">
-			<svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 -960 960 960" width="48px" fill="currentColor">
+			<svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 -960 960 960" width="48px"
+				fill="currentColor">
 				<path
 					d="M480-323.39 314.31-489.08l32.61-32.23 110.39 110V-780h45.38v368.69l110.39-110 32.61 32.23L480-323.39ZM237.69-180q-23.53 0-40.61-17.08T180-237.69V-363h45.39v125.31q0 4.61 3.84 8.46 3.85 3.84 8.46 3.84h484.62q4.61 0 8.46-3.84 3.84-3.85 3.84-8.46V-363H780v125.31q0 23.53-17.08 40.61T722.31-180H237.69Z" />
 			</svg>
@@ -224,9 +225,38 @@
 				if (autoTimer) { clearInterval(autoTimer); autoTimer = null; }
 			}
 
-			// Pause on hover; resume on leave [Can be done]
-			// document.body.addEventListener('mouseenter', stopAuto);
-			// document.body.addEventListener('mouseleave', startAuto);
+			// --- TOUCH SWIPE LOGIC START ---
+			let touchStartX = 0;
+			let touchEndX = 0;
+
+			function handleSwipe() {
+				const swipeThreshold = 50; // Minimum pixel distance for a valid swipe
+
+				if (touchEndX < touchStartX - swipeThreshold) {
+					// Swiped Left -> Next item
+					stopAuto();
+					currentIndex = (currentIndex + 1) % items.length;
+					renderItem(currentIndex);
+					startAuto();
+				} else if (touchEndX > touchStartX + swipeThreshold) {
+					// Swiped Right -> Previous item
+					stopAuto();
+					// Using `+ items.length` ensures we don't get negative values when wrapping around backwards
+					currentIndex = (currentIndex - 1 + items.length) % items.length;
+					renderItem(currentIndex);
+					startAuto();
+				}
+			}
+
+			document.addEventListener('touchstart', e => {
+				touchStartX = e.changedTouches[0].screenX;
+			}, { passive: true });
+
+			document.addEventListener('touchend', e => {
+				touchEndX = e.changedTouches[0].screenX;
+				handleSwipe();
+			}, { passive: true });
+			// --- TOUCH SWIPE LOGIC END ---
 
 			function buildDots() {
 				const container = $('carousel-dots');


### PR DESCRIPTION
  This PR introduces touch gesture navigation to the Spotlight carousel, improving the user experience on mobile and touch-enabled devices.

its more intuitive for mobile devices then clicking on dots to navigate. 

CSS Optimization: Added touch-action: pan-y to the global styles to prevent mobile browsers from triggering history navigation (back/forward) during horizontal swipes.


  Technical Details:
   - Added a swipeThreshold of 50px to prevent accidental triggers during taps.
   - Integrated stopAuto() and startAuto() within the swipe handlers to ensure the timer resets whenever a user manually interacts with the carousel.