### PR TITLE
Fix jsDelivr purge paths for styles/ overrides + two installer bugs

### DIFF
--- a/.github/workflows/purge-jsdelivr-cdn.yml
+++ b/.github/workflows/purge-jsdelivr-cdn.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Purge jsDelivr cache for abyss.css
         run: |
           curl -s "https://purge.jsdelivr.net/gh/AumGupta/abyss-jellyfin@main/abyss.css"
-          curl -s "https://purge.jsdelivr.net/gh/AumGupta/abyss-jellyfin@main/abyss-je.css"
-          curl -s "https://purge.jsdelivr.net/gh/AumGupta/abyss-jellyfin@main/abyss-mbe.css"
-          echo "CDN purge triggered for abyss.css"
+          curl -s "https://purge.jsdelivr.net/gh/AumGupta/abyss-jellyfin@main/styles/abyss-je.css"
+          curl -s "https://purge.jsdelivr.net/gh/AumGupta/abyss-jellyfin@main/styles/abyss-mbe.css"
+          echo "CDN purge triggered for abyss.css and styles/ overrides"

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ For detailed steps go to the [Setup Guide](SETUP.md).
 
 ### Docker Install
 
-The steps to install Abyss inside a docker container can be found the detailed [SETUP](SETUP.md) guide.
+The steps to install Abyss inside a docker container can be found in the detailed [SETUP](SETUP.md) guide.
 
 ### Manual Install
 
-The steps to apply Abyss etirely manually can be found the detailed [SETUP](SETUP.md) guide.
+The steps to apply Abyss entirely manually can be found in the detailed [SETUP](SETUP.md) guide.
 
 > Quick Preview: 
 > ```css

--- a/scripts/spotlight/spotlight.html
+++ b/scripts/spotlight/spotlight.html
@@ -39,7 +39,7 @@
 					d="M480-323.39 314.31-489.08l32.61-32.23 110.39 110V-780h45.38v368.69l110.39-110 32.61 32.23L480-323.39ZM237.69-180q-23.53 0-40.61-17.08T180-237.69V-363h45.39v125.31q0 4.61 3.84 8.46 3.85 3.84 8.46 3.84h484.62q4.61 0 8.46-3.84 3.84-3.85 3.84-8.46V-363H780v125.31q0 23.53-17.08 40.61T722.31-180H237.69Z" />
 			</svg>
 			<span id="update-text"></span>
-			<a id="update-link" href="#" target="_blank" rel="noopener noreferrer" id="update-link">View release</a>
+			<a id="update-link" href="#" target="_blank" rel="noopener noreferrer">View release</a>
 			<button id="update-dismiss" aria-label="Dismiss notification">
 				<svg xmlns="http://www.w3.org/2000/svg" height="14px" viewBox="0 -960 960 960" width="14px"
 					fill="currentColor">

--- a/setup.ps1
+++ b/setup.ps1
@@ -225,7 +225,8 @@ function Install-Abyss {
         Write-Info "Recommended order: Continue Watching, Next Up, My Media, Recently Added."
         Write-Info "(Recommended for best experience with Abyss)"
         $reorderChoice = Read-Host "  Reorder sections? [Y/n]"
-        if ($reorderChoice.Trim().ToUpper() -eq "Y") {
+        # [Y/n] convention: ENTER (empty) defaults to Yes
+        if ($reorderChoice.Trim() -eq "" -or $reorderChoice.Trim().ToUpper() -eq "Y") {
             $displayPrefs.CustomPrefs.homesection0 = "resume"
             $displayPrefs.CustomPrefs.homesection1 = "nextup"
             $displayPrefs.CustomPrefs.homesection2 = "smalllibrarytiles"

--- a/setup.sh
+++ b/setup.sh
@@ -104,13 +104,16 @@ get_jellyfin_web_dir() {
         fi
     done
 
-    warn "Could not auto-detect Jellyfin web directory."
-    echo -e "${yellow}  Enter the full path to your jellyfin-web folder:${reset}"
+    # This function's stdout is captured by the caller ($(get_jellyfin_web_dir)),
+    # so all user-facing prompts must go to stderr or they get swallowed into
+    # the return value.
+    warn "Could not auto-detect Jellyfin web directory." >&2
+    echo -e "${yellow}  Enter the full path to your jellyfin-web folder:${reset}" >&2
     if [[ "$OS" == "Darwin" ]]; then
-        info "Example: /opt/homebrew/share/jellyfin/web"
+        info "Example: /opt/homebrew/share/jellyfin/web" >&2
     else
-        info "Example: /usr/share/jellyfin/web"
-        info "/Applications/Jellyfin.app/Contents/Resources/jellyfin-web"
+        info "Example: /usr/share/jellyfin/web" >&2
+        info "/Applications/Jellyfin.app/Contents/Resources/jellyfin-web" >&2
     fi
     read -rp "  Path: " path
     if [[ ! -d "$path" ]]; then
@@ -342,6 +345,8 @@ print(json.dumps(d))
         info "(Recommended for best experience with Abyss)"
         read -rp "  Reorder sections? [Y/n]: " reorder_choice
         echo ""
+        # [Y/n] convention: ENTER (empty) defaults to Yes
+        [[ -z "${reorder_choice// }" ]] && reorder_choice="Y"
 
         local updated_prefs
         if [[ "${reorder_choice^^}" == "Y" ]]; then


### PR DESCRIPTION
## Summary

Three small fixes found while reading through the installers and CI:

### 1. CDN purge never fires for the plugin override styles (`.github/workflows/purge-jsdelivr-cdn.yml`)
The workflow triggers on `styles/abyss-je.css` / `styles/abyss-mbe.css` but purged root-level URLs (`…@main/abyss-je.css`) that don't exist — jsDelivr paths mirror the repo layout, and SETUP.md tells users to `@import …@main/styles/abyss-je.css`. So any update to the Jellyfin Enhanced / Media Bar Enhanced overrides kept serving stale CSS from the CDN cache until it expired on its own. Added the `styles/` prefix.

### 2. `setup.sh`: manual web-dir prompt is invisible and corrupts the returned path
`get_jellyfin_web_dir` returns its result via stdout, captured with `web_dir=$(get_jellyfin_web_dir)`. When auto-detect fails, the `warn`/`info` guidance lines also went to stdout — so the user never saw the "Enter the full path…" guidance, and those lines were swallowed into `$web_dir`, producing a multi-line garbage path that `mkdir -p` would then partially create. The prompts now go to `>&2` (with a comment explaining why). Verified with a small harness: the captured value is now exactly the entered path.

### 3. `[Y/n]` prompt treated ENTER as No (`setup.ps1` + `setup.sh`)
The "Reorder sections? [Y/n]" prompt uses the capital-Y convention (ENTER = Yes), but both installers only matched a literal `Y`/`y`, so pressing ENTER silently skipped the recommended home-section setup. Empty input now defaults to Yes.

Also included (trivial): removed a duplicate `id` attribute on the update-toast link in `spotlight.html`, and fixed two README typos ("etirely", "found ~~the~~ → found in the").

## Testing
- `bash -n setup.sh` passes; the stderr fix verified with a stub harness (captured return value is clean)
- `setup.ps1` parses clean via `[Language.Parser]::ParseFile`
- Confirmed `styles/abyss-je.css` / `styles/abyss-mbe.css` are the actual repo paths users import per SETUP.md

Nice theme, by the way — the installer transparency (plain readable PS1 → PS2EXE via Actions) is a great touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)