### PR TITLE
fix: legacy-engine CSS fallbacks for Jellyfin Media Player (Qt5)

### DIFF
--- a/abyss.css
+++ b/abyss.css
@@ -423,7 +423,7 @@ body:has(#itemDetailPage) .backdropImage {
     padding: 5px 2.5px;
     overflow: scroll;
     scrollbar-width: none;
-    background-color: rgba(var(--abyss-glass-tint), 0.35);
+    background-color: rgba(var(--abyss-glass-tint), 0.9);
     box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
     border: 1px solid rgba(87, 87, 87, 0.18);
 }

--- a/abyss.css
+++ b/abyss.css
@@ -421,11 +421,16 @@ body:has(#itemDetailPage) .backdropImage {
 .emby-tabs-slider {
     border-radius: 50px;
     padding: 5px 2.5px;
-    overflow: scroll;
+    overflow: auto;
     scrollbar-width: none;
     background-color: rgba(var(--abyss-glass-tint), 0.9);
     box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
     border: 1px solid rgba(87, 87, 87, 0.18);
+}
+
+/* Engines without scrollbar-width support (Chromium <121, e.g. JMP) */
+.emby-tabs-slider::-webkit-scrollbar {
+    display: none;
 }
 
 .navMenuOptionText {

--- a/scripts/spotlight/spotlight.css
+++ b/scripts/spotlight/spotlight.css
@@ -66,7 +66,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-end;
-	padding: 25dvh 4.3vw 6.5vh;
+	padding: 25vh 4.3vw 6.5vh;
 	opacity: 0;
 	transform: translateY(0);
 	transition: opacity 0.7s var(--ease), transform 0.5s var(--ease);
@@ -77,7 +77,7 @@ body {
 }
 
 #logo {
-	max-width: 55dvw;
+	max-width: 55vw;
 	max-height: 120px;
 	object-fit: contain;
 	object-position: left bottom;
@@ -443,7 +443,7 @@ body {
 	}
 
 	#logo {
-		max-width: 100dvw;
+		max-width: 100vw;
 		max-height: 150px;
 		margin-bottom: 2px;
 	}
@@ -470,7 +470,7 @@ body {
 	}
 
 	#logo {
-		max-width: 35dvw;
+		max-width: 35vw;
 		max-height: 120px;
 		margin-bottom: 2px;
 	}


### PR DESCRIPTION
Fixes #54

## Problem

Jellyfin Media Player v1.12.0 (last Qt 5 release) embeds QtWebEngine based on Chromium ~87. Several modern CSS features used by Abyss are unsupported there, breaking the home screen while web/mobile clients look fine:

1. **Spotlight banner loses all padding** (the issue #54 screenshots): `spotlight.css` uses `dvh`/`dvw` dynamic viewport units (Chromium 108+). Old engines drop the entire declaration on an unknown unit, so `#content { padding: 25dvh 4.3vw 6.5vh }` falls back to `padding: 0` from the reset - logo, title, and buttons sit flush against the window edge, and the logo loses its `max-width: 55dvw` cap.
2. **Header tab pill looks translucent/washed out**: QtWebEngine has no working `backdrop-filter`, so the `@supports` glass upgrade (blur + 0.69 tint) never applies and the pill falls back to a very translucent `rgba(..., 0.35)` background.
3. **Tab pill taller at the bottom with squared bands**: `.emby-tabs-slider` uses `overflow: scroll` + `scrollbar-width: none`, but `scrollbar-width` needs Chromium 121+, so always-on scrollbar gutters render inside the pill.

## Fix

- `spotlight.css`: swap `dvh`/`dvw` for `vh`/`vw`. Lossless - the spotlight runs in an iframe, where dynamic and static viewport units are always identical (dynamic units only differ under retractable browser UI on the top-level viewport). Gains Chromium <108 compat.
- `abyss.css`: raise the tab-slider fallback background to `rgba(var(--abyss-glass-tint), 0.9)`. Capable engines still get the frosted `0.69` + blur via the existing `@supports` override.
- `abyss.css`: `overflow: scroll` -> `overflow: auto` on the tab slider, plus a `::-webkit-scrollbar { display: none }` fallback for engines without `scrollbar-width` (inert on engines that support it).

## Testing

Verified on Jellyfin 10.11.11 (linuxserver docker) with Jellyfin Media Player 1.12.0 on macOS: spotlight padding and logo cap restored, tab pill solid and evenly sized. Web client visually unchanged.