### PR TITLE
fix: broken search result cards scroll handling

### DIFF
--- a/abyss.css
+++ b/abyss.css
@@ -2190,10 +2190,6 @@ div[data-role="controlgroup"] a[data-role="button"]:last-child {
     background: transparent;
 }
 
-#searchPage .scrollSlider {
-    overflow: hidden !important;
-}
-
 .noItemsMessage.centerMessage {
     font-weight: 100 !important;
     font-size: 36px;


### PR DESCRIPTION
The overflow style breaks scrolling of search cards on mobile devices and on desktop devices search result cards beyond the initial visible cards are not loaded properly after scrolling.

Removing the ```overflow: hidden``` style fixes these issues. 

Tested the fix on:
- iOS 26 .6 Safari and iOS Jellyfin Application
- iPadOS 26.6 Jellyfin Application
- MacOS Safari web browser
- MacOS Chromium browser

Observed no other side efffect from the change.