### PR TITLE
fix: bump spotlight version constant to 1.2.2

### DIFF
--- a/scripts/spotlight/spotlight.html
+++ b/scripts/spotlight/spotlight.html
@@ -57,7 +57,7 @@
 
 	<script>
 		// Updated automatically by the installer on each install/update.
-		const ABYSS_SPOTLIGHT_VERSION = '1.2.1';
+		const ABYSS_SPOTLIGHT_VERSION = '1.2.2';
 
 		(() => {
 			const $ = id => document.getElementById(id);


### PR DESCRIPTION
## Summary
- Fixes #90 — `ABYSS_SPOTLIGHT_VERSION` in `scripts/spotlight/spotlight.html` was still `1.2.1` on `main`, even though the latest release is `v1.2.2`, causing a permanent false "update available" toast for anyone running current `main` (including via the official installer).

## Root cause
`update-spotlight-version.yml` already bumps this constant automatically on every release, and it worked correctly for the `v1.2.2` release. However, an unrelated commit (`d6a226b`, "improve update toast layout and styling for better visibility") reverted the constant from `1.2.2` back to `1.2.1` as a side effect of being based on a stale branch. This PR just restores the correct value.

## Test plan
- [x] Confirm the toast no longer appears on a fresh load of `main` when the latest release is `v1.2.2`.