### PR TITLE
fix: update Google Sans font weight range to fix broken font link

### DIFF
--- a/scripts/spotlight/spotlight.html
+++ b/scripts/spotlight/spotlight.html
@@ -7,7 +7,7 @@
 	<title>Abyss Spotlight</title>
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link
-		href="https://fonts.googleapis.com/css2?family=Google+Sans:ital,opsz,wght@0,17..18,300..700;1,17..18,300..700&display=swap"
+		href="https://fonts.googleapis.com/css2?family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&display=swap"
 		rel="stylesheet" />
 	<link rel="stylesheet" href="spotlight.css" />
 </head>


### PR DESCRIPTION
The weight range 300..700 for the variable font is no longer served by Google Fonts for this family/opsz combination, causing an HTTP error (400). Narrowed the range to 400..700, matching the weights actually used in the theme's CSS, with no visual impact.
